### PR TITLE
Set initial scale

### DIFF
--- a/wcomponents-theme/src/main/sass/mixins_respond.scss
+++ b/wcomponents-theme/src/main/sass/mixins_respond.scss
@@ -60,3 +60,15 @@ $large: 2000px;
 		}
 	}
 }
+
+// create a viewport media rule
+@mixin viewport() {
+	@-ms-viewport {
+		@content
+
+	}
+
+	@viewport {
+		@content
+	}
+}

--- a/wcomponents-theme/src/main/sass/wc.common.page.scss
+++ b/wcomponents-theme/src/main/sass/wc.common.page.scss
@@ -110,4 +110,11 @@ a[name],
 input[type='number'][maxlength] {
 	@include outline($color: $wc-ui-color-error-fg);
 }
+
+
+@include viewport {
+	user-zoom: zoom;
+	width: extend-to-zoom;
+	zoom: 1;
+}
 /* end wc.common.page.scss */

--- a/wcomponents-theme/src/main/xslt/wc.ui.root.n.addHeadMetaBeforeTitle.xsl
+++ b/wcomponents-theme/src/main/xslt/wc.ui.root.n.addHeadMetaBeforeTitle.xsl
@@ -1,19 +1,20 @@
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">	
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ui="https://github.com/bordertech/wcomponents/namespace/ui/v1.0" xmlns:html="http://www.w3.org/1999/xhtml" version="1.0">
 	<xsl:import href="wc.ui.root.n.includeFavicon.xsl"/>
 	<!--
-		There may be occasions when you want to add very early meta elements to the head (such as adding an IE 
+		There may be occasions when you want to add very early meta elements to the head (such as adding an IE
 		compatibility meta). This template is here for EXACTLY that purpose.
-		
-		The format-detection is needed to work around issues in some very popular mobile browsers that will convert
-		"numbers" into phone links (a elements) if they appear to be phone numbers, even if those numbers are the
-		content of buttons or links. This breaks important stuff if you, for example, want to link or submit using
-		a number identifier.
-		
-		If you want a phone number link in these (or any) browser use WPhoneNumberField set readOnly.
 	-->
 	<xsl:template name="addHeadMetaBeforeTitle">
 		<!-- Works more reliably if it is first -->
 		<xsl:call-template name="includeFavicon"/>
+		<!--
+		The format-detection is needed to work around issues in some very popular mobile browsers that will convert
+		"numbers" into phone links (a elements) if they appear to be phone numbers, even if those numbers are the
+		content of buttons or links. This breaks important stuff if you, for example, want to link or submit using
+		a number identifier.
+
+		If you want a phone number link in these (or any) browser use WPhoneNumberField set readOnly.
+		-->
 		<xsl:element name="meta">
 			<xsl:attribute name="name">
 				<xsl:text>format-detection</xsl:text>
@@ -21,6 +22,10 @@
 			<xsl:attribute name="content">
 				<xsl:text>telephone=no</xsl:text>
 			</xsl:attribute>
+		</xsl:element>
+		<xsl:element name="meta">
+			<xsl:attribute name="name"><xsl:text>viewport</xsl:text></xsl:attribute>
+			<xsl:attribute name="content"><xsl:text>initial-scale=1</xsl:text></xsl:attribute>
 		</xsl:element>
 	</xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Added viewport mixin and scss and a viewport meta element. These are to
set the initial scale of an application to 1 and still allow zooming
for a11y.