### PR TITLE
Theme enhancements

### DIFF
--- a/wcomponents-theme/src/main/images/backToTop.svg
+++ b/wcomponents-theme/src/main/images/backToTop.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="0 0 100 100" width="100%" height="100%" preserveAspectRatio="xMidYMid" version="1.1" xmlns="http://www.w3.org/2000/svg">
 	<g fill="#000000" stroke-width="0">
-		<circle cx="50" cy="50" r="50" style="opacity:${wc.ui.backToTop.opacity.bg};"/>
-		<path d="M50,10l40,30h-20v40h-40v-40h-20z"  style="opacity:${wc.ui.backToTop.opacity.fg};"/>
+		<circle cx="50" cy="50" r="50" style="opacity:0.1;"/>
+		<path d="M50,10l40,30h-20v40h-40v-40h-20z" style="opacity:0.25;"/>
 	</g>
 </svg>

--- a/wcomponents-theme/src/main/js/wc/dom/ariaAnalog.js
+++ b/wcomponents-theme/src/main/js/wc/dom/ariaAnalog.js
@@ -635,8 +635,8 @@ define(["wc/has",
 				groupAction = shed.select;
 			}
 			filter = getFilteredGroup.FILTERS.visible | getFilteredGroup.FILTERS.enabled;
-			filtered = getFilteredGroup(element, {filter: (filter | selectedFilter)});
-			unfiltered = getFilteredGroup(element, {filter: filter});
+			filtered = getFilteredGroup(element, {filter: (filter | selectedFilter), containerWd: this.CONTAINER, itemWd: (this.CONTAINER ? this.ITEM : null)});
+			unfiltered = getFilteredGroup(element, {filter: filter, containerWd: this.CONTAINER, itemWd: (this.CONTAINER ? this.ITEM : null)});
 
 			if (filtered && filtered.length) {
 				start = Math.min(unfiltered.indexOf(element), unfiltered.indexOf(lastActivated));

--- a/wcomponents-theme/src/main/js/wc/ui/ajax/genericSubscriber.js
+++ b/wcomponents-theme/src/main/js/wc/ui/ajax/genericSubscriber.js
@@ -7,11 +7,10 @@
  * @requires module:wc/dom/initialise
  * @requires module:wc/ui/ajaxRegion
  * @requires module:wc/ui/ajax/processResponse
- * @requires module:wc/dom/tag
  */
-define(["wc/dom/initialise", "wc/ui/ajaxRegion", "wc/ui/ajax/processResponse", "wc/dom/tag"],
-	/** @param initialise wc/dom/initialise @param ajaxRegion wc/ui/ajaxRegion @param processResponse wc/ui/ajax/processResponse @param tag wc/dom/tag @ignore */
-	function(initialise, ajaxRegion, processResponse, tag) {
+define(["wc/dom/initialise", "wc/ui/ajaxRegion", "wc/ui/ajax/processResponse"],
+	/** @param initialise wc/dom/initialise @param ajaxRegion wc/ui/ajaxRegion @param processResponse wc/ui/ajax/processResponse @ignore */
+	function(initialise, ajaxRegion, processResponse) {
 		"use strict";
 
 		/**

--- a/wcomponents-theme/src/main/js/wc/ui/backToTop.js
+++ b/wcomponents-theme/src/main/js/wc/ui/backToTop.js
@@ -2,6 +2,11 @@
  * Provides functionality to provide a back to top link which is scroll and viewport size aware. Not functional in IE
  * below 10.
  *
+ * @typedef {Object} module:wc/ui/backToTop.config() Optional module configuration.
+ * @property {?int} scroll The number of pixels of scroll required before the back to top link is displayed. Undefined
+ * or zero results in the link displaying after 1 viewport of scroll.
+ * @default 0
+ *
  * @module
  * @requires module:wc/i18n/i18n
  * @requires module:wc/dom/event
@@ -12,9 +17,9 @@
  * @requires module:wc/dom/Widget
  * @requires module:wc/has
  */
-define(["wc/i18n/i18n", "wc/dom/event", "wc/dom/focus", "wc/dom/initialise", "wc/dom/getViewportSize", "wc/dom/shed", "wc/dom/Widget", "wc/has"],
-	/** @param i18n wc/i18n/i18n @param event wc/dom/event @param focus wc/dom/focus @param initialise wc/dom/initialise @param getViewportSize wc/dom/getViewportSize @param shed wc/dom/shed @param Widget wc/dom/Widget @param has wc/has @ignore */
-	function(i18n, event, focus, initialise, getViewportSize, shed, Widget, has) {
+define(["wc/i18n/i18n", "wc/dom/event", "wc/dom/focus", "wc/dom/initialise", "wc/dom/getViewportSize", "wc/dom/shed", "wc/dom/Widget", "wc/has", "module"],
+	/** @param i18n wc/i18n/i18n @param event wc/dom/event @param focus wc/dom/focus @param initialise wc/dom/initialise @param getViewportSize wc/dom/getViewportSize @param shed wc/dom/shed @param Widget wc/dom/Widget @param has wc/has @param module @ignore */
+	function(i18n, event, focus, initialise, getViewportSize, shed, Widget, has, module) {
 		"use strict";
 
 		if (has("ie")) {
@@ -39,12 +44,15 @@ define(["wc/i18n/i18n", "wc/dom/event", "wc/dom/focus", "wc/dom/initialise", "wc
 				 * This property can be set to a positive integer to force showing the scroll to top link at X pixels of
 				 * scroll. If it is not set (or set to 0) then the scroll to top link will appear when more than one
 				 * viewport height of scroll has occurred.
+				 *
+				 * Can be set in module configuration as property "scroll".
+				 *
 				 * @constant
 				 * @type {int}
 				 * @private
-				 * @default "${wc.ui.backToTop.MIN_SCROLL_BEFORE_SHOW}"
+				 * @default 0
 				 */
-				MIN_SCROLL_BEFORE_SHOW = "${wc.ui.backToTop.MIN_SCROLL_BEFORE_SHOW}",
+				MIN_SCROLL_BEFORE_SHOW = (module.config() ? (module.config().scroll || 0) : 0),
 				/**
 				 * Is the back to top link enabled?
 				 * @var
@@ -152,7 +160,6 @@ define(["wc/i18n/i18n", "wc/dom/event", "wc/dom/focus", "wc/dom/initialise", "wc
 			 *
 			 * @function module:wc/ui/backToTop.initialise
 			 * @public
-			 * @param {Element} element The element being initialised, usually document.body
 			 */
 			this.initialise = function(/* element */) {
 				if (isEnabled) {

--- a/wcomponents-theme/src/main/js/wc/ui/calendar.js
+++ b/wcomponents-theme/src/main/js/wc/ui/calendar.js
@@ -2,6 +2,12 @@
  * Provides a calendar based date chooser control for use by WDateFields when a native date control is not available
  * and WPartialDateFields in all cases.
  *
+ * @typedef {Object} module:wc/ui/calendar.config() Optional module configuration.
+ * @property {?int} min The minimum year to allow in the date picker.
+ * @default 1000
+ * @property {?int} max The maximum year to allow in the date picker.
+ * @default 9999.
+ *
  * @module
  * @requires module:wc/dom/attribute
  * @requires module:wc/date/addDays
@@ -55,10 +61,12 @@ define(["wc/dom/attribute",
 		"wc/isNumeric",
 		"wc/ui/dateField",
 		"wc/dom/initialise",
-		"wc/timers"],
-/** @param attribute wc/dom/attribute @param addDays wc/date/addDays @param copy wc/date/copy @param dayName wc/date/dayName @param daysInMonth wc/date/daysInMonth @param getDifference wc/date/getDifference @param monthName wc/date/monthName @param today wc/date/today @param interchange wc/date/interchange @param classList wc/dom/classList @param event wc/dom/event @param focus wc/dom/focus @param shed wc/dom/shed @param tag wc/dom/tag @param viewportCollision wc/dom/viewportCollision @param getBox wc/dom/getBox @param Widget wc/dom/Widget @param i18n wc/i18n/i18n @param loader wc/loader/resource @param sprintf sprintf/sprintf @param isNumeric wc/isNumeric @param dateField wc/ui/dateField @param initialise wc/dom/initialise @param timers wc/timers @ignore */
+		"wc/timers",
+		"module"],
+/** @param attribute wc/dom/attribute @param addDays wc/date/addDays @param copy wc/date/copy @param dayName wc/date/dayName @param daysInMonth wc/date/daysInMonth @param getDifference wc/date/getDifference @param monthName wc/date/monthName @param today wc/date/today @param interchange wc/date/interchange @param classList wc/dom/classList @param event wc/dom/event @param focus wc/dom/focus @param shed wc/dom/shed @param tag wc/dom/tag @param viewportCollision wc/dom/viewportCollision @param getBox wc/dom/getBox @param Widget wc/dom/Widget @param i18n wc/i18n/i18n @param loader wc/loader/resource @param sprintf sprintf/sprintf @param isNumeric wc/isNumeric @param dateField wc/ui/dateField @param initialise wc/dom/initialise @param timers wc/timers @param module @ignore */
 function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthName, today, interchange, classList, event,
-		focus, shed, tag, viewportCollision, getBox, Widget, i18n, loader, sprintf, isNumeric, dateField, initialise, timers) {
+		focus, shed, tag, viewportCollision, getBox, Widget, i18n, loader, sprintf, isNumeric, dateField, initialise,
+		timers, module) {
 
 	"use strict";
 
@@ -68,7 +76,8 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 	 * @private
 	 */
 	function Calendar() {
-		var DATE_KEY = "date_key", CONTAINER_ID = "wc-calbox",
+		var DATE_KEY = "date_key",
+			CONTAINER_ID = "wc-calbox",
 			DAY_CONTAINER_ID = "wc-caldaybox",
 			MONTH_SELECT_ID = "wc-calmonth",
 			YEAR_ELEMENT_ID = "wc-calyear",
@@ -87,11 +96,13 @@ function(attribute, addDays, copy, dayName, daysInMonth, getDifference, monthNam
 			CAL_BUTTON = new Widget("button", "wc_wdf_mv"),
 			CLOSE_BUTTON = new Widget("button", "wc_wdf_cls"),
 			isOpening = false,
-			yearChangedTimeout, refocusId,
+			yearChangedTimeout,
+			refocusId,
 			MIN_ATTRIB = "min",
 			MAX_ATTRIB = "max",
-			MIN_YEAR = 1000,
-			MAX_YEAR = 9999;
+			conf = module.config(),
+			MIN_YEAR = ((conf && conf.min) ? conf.min : 1000),
+			MAX_YEAR = ((conf && conf.max) ? conf.max : 9999);
 
 
 		function findMonthSelect() {

--- a/wcomponents-theme/src/main/js/wc/ui/checkboxAnalog.js
+++ b/wcomponents-theme/src/main/js/wc/ui/checkboxAnalog.js
@@ -12,9 +12,9 @@
  * @requires module:wc/dom/shed
  * @requires module:wc/dom/formUpdateManager
  */
-define(["wc/dom/ariaAnalog", "wc/dom/initialise", "wc/dom/Widget", "wc/dom/shed", "wc/dom/formUpdateManager"],
-	/** @param ariaAnalog wc/dom/ariaAnalog @param initialise wc/dom/initialise @param Widget wc/dom/Widget @param shed wc/dom/shed @param formUpdateManager wc/dom/formUpdateManager @ignore */
-	function(ariaAnalog, initialise, Widget, shed, formUpdateManager) {
+define(["wc/dom/ariaAnalog", "wc/dom/initialise", "wc/dom/Widget", "wc/dom/shed", "wc/dom/formUpdateManager", "wc/ui/table/rowCheckbox"],
+	/** @param ariaAnalog wc/dom/ariaAnalog @param initialise wc/dom/initialise @param Widget wc/dom/Widget @param shed wc/dom/shed @param formUpdateManager wc/dom/formUpdateManager @param rowCheckbox @ignore */
+	function(ariaAnalog, initialise, Widget, shed, formUpdateManager, rowCheckbox) {
 		"use strict";
 
 		/**
@@ -46,14 +46,30 @@ define(["wc/dom/ariaAnalog", "wc/dom/initialise", "wc/dom/Widget", "wc/dom/shed"
 				var SELECTED_ITEM = this.ITEM.extend("", {"aria-checked": "true"}),
 					items = SELECTED_ITEM.findDescendants(form);
 
-				function writeItemState(next) {
-					if (next.hasAttribute("data-wc-value") && !shed.isDisabled(next)) {
-						formUpdateManager.writeStateField(container, next.getAttribute("data-wc-name"), next.getAttribute("data-wc-value"));
-					}
-				}
-
 				if (items.length) {
-					Array.prototype.forEach.call(items, writeItemState);
+					Array.prototype.forEach.call(items, function(next) {
+						if (next.hasAttribute("data-wc-value") && !shed.isDisabled(next)) {
+							formUpdateManager.writeStateField(container, next.getAttribute("data-wc-name"), next.getAttribute("data-wc-value"));
+						}
+					});
+				}
+			};
+
+			/**
+			 * Click handler to deal with ambiguity of table row check boxes and other fake checkboxes.
+			 * @function
+			 * @public
+			 * @override
+			 * @param {Event} $event A click event.
+			 * @todo Do this better without the leaky abstraction!
+			 */
+			this.clickEvent = function($event) {
+				var target = $event.target, element;
+				if (!$event.defaultPrevented && (element = this.getActivableFromTarget(target))) {
+					if (rowCheckbox.ITEM.isOneOfMe(element)) {
+						return;
+					}
+					this.constructor.prototype.clickEvent.call(this, $event);
 				}
 			};
 		}

--- a/wcomponents-theme/src/main/js/wc/ui/comboBox.js
+++ b/wcomponents-theme/src/main/js/wc/ui/comboBox.js
@@ -1,5 +1,14 @@
 /**
  * Provides combo functionality.
+ *
+ * @typedef {Object} module:wc/ui/comboBox.config() Optional module configuration.
+ * @property {?int} min The global (default) minimum number of characters which must be entered before a comboBox will
+ * update its dynamic datalist. This can be over-ridden per instance of WSuggestions.
+ * @default 3
+ * @property {?int} delay The number of milliseconds for which a user must pause before a comboBox's datalist is
+ * updated.
+ * @default 333
+ *
  * @module
  * @requires module:wc/has
  * @requires module:wc/ajax/triggerManager
@@ -35,9 +44,11 @@ define(["wc/has",
 		"wc/ui/ajaxRegion",
 		"wc/ui/ajax/processResponse",
 		"wc/ui/onchangeSubmit",
-		"wc/ui/listboxAnalog"],
-	/** @param has wc/has @param triggerManager wc/ajax/triggerManager @param attribute wc/dom/attribute @param classList wc/dom/classList @param event wc/dom/event @param focus wc/dom/focus @param getFilteredGroup wc/dom/getFilteredGroup @param initialise wc/dom/initialise @param shed wc/dom/shed @param textContent wc/dom/textContent @param Widget wc/dom/Widget @param key wc/key @param timers wc/timers @param ajaxRegion wc/ui/ajaxRegion @param processResponse wc/ui/ajax/processResponse @param onchangeSubmit wc/ui/onchangeSubmit @ignore */
-	function(has, triggerManager, attribute, classList, event, focus, getFilteredGroup, initialise, shed, textContent, Widget, key, timers, ajaxRegion, processResponse, onchangeSubmit) {
+		"wc/ui/listboxAnalog",
+		"module"
+	],
+	/** @param has wc/has @param triggerManager wc/ajax/triggerManager @param attribute wc/dom/attribute @param classList wc/dom/classList @param event wc/dom/event @param focus wc/dom/focus @param getFilteredGroup wc/dom/getFilteredGroup @param initialise wc/dom/initialise @param shed wc/dom/shed @param textContent wc/dom/textContent @param Widget wc/dom/Widget @param key wc/key @param timers wc/timers @param ajaxRegion wc/ui/ajaxRegion @param processResponse wc/ui/ajax/processResponse @param onchangeSubmit wc/ui/onchangeSubmit @param module @ignore */
+	function(has, triggerManager, attribute, classList, event, focus, getFilteredGroup, initialise, shed, textContent, Widget, key, timers, ajaxRegion, processResponse, onchangeSubmit, listboxAnalog, module) {
 		"use strict";
 		// listboxAnalog is required but not used.
 
@@ -63,8 +74,21 @@ define(["wc/has",
 				CLASS_CHATTY = "wc_combo_dyn",
 				CHATTY_COMBO = COMBO.extend(CLASS_CHATTY),
 				updateTimeout,
-				DELAY = 333,  // wait this long before updating the list on keydown
-				DEFAULT_CHARS = 3,  // only update the list if the user has entered at least this number of characters
+				conf = module.config(),
+				/**
+				 * Wait this long before updating the list on keydown.
+				 * @var
+				 * @type Number
+				 * @private
+				 */
+				DELAY = (conf ? (conf.delay || 333) : 333),
+				/**
+				 * Only update the list if the user has entered at least this number of characters.
+				 * @var
+				 * @type Number
+				 * @private
+				 */
+				DEFAULT_CHARS = (conf ? (conf.min || 3) : 3),
 				CHAR_KEYS,  // used in the keydown event handler if we cannot use the input event
 				nothingLeftReg = {};  // last search returned no match, keep the search term for future reference
 
@@ -788,7 +812,7 @@ define(["wc/has",
 			/**
 			 * Set client side list filtering on or off. Public for testing as most of the unit tests require we
 			 * do not do list filtering in the client and therefore no equivalent used internally.
-			 * @function  module:wc/ui/comboBox._setFilter
+			 * @function module:wc/ui/comboBox._setFilter
 			 * @param {boolean} [set] force on (true) or off.
 			 * @ignore
 			 */

--- a/wcomponents-theme/src/main/js/wc/ui/draggable.js
+++ b/wcomponents-theme/src/main/js/wc/ui/draggable.js
@@ -1,6 +1,10 @@
 /**
  * Provides functionality used to move a component around the screen. Components may be moved using a mouse or keyboard.
  *
+ * @typedef {Object} module:wc/ui/draggable.config() Optional module configuration
+ * @property {int} step The number of pixels to move the draggable element per key press.
+ * @default 6
+ *
  * @module
  * @requires module:wc/dom/attribute
  * @requires module:wc/dom/classList
@@ -30,9 +34,10 @@ define(["wc/dom/attribute",
 		"wc/dom/Widget",
 		"wc/has",
 		"wc/ui/ajax/processResponse",
-		"wc/ui/positionable"],
-	/** @param attribute wc/dom/attribute @param classList wc/dom/classList @param clearSelection wc/dom/clearSelection @param event wc/dom/event @param getMouseEventOffset wc/dom/getEventOffset @param isAcceptableEventTarget wc/dom/isAcceptableTarget @param getBox wc/dom/getBox @param initialise wc/dom/initialise @param shed wc/dom/shed @param uid wc/dom/uid @param Widget wc/dom/Widget @param has wc/has @param processResponse wc/ui/ajax/processResponse @param positionable wc/ui/positionable @ignore */
-	function(attribute, classList, clearSelection, event, getMouseEventOffset, isAcceptableEventTarget, getBox, initialise, shed, uid, Widget, has, processResponse, positionable) {
+		"wc/ui/positionable",
+		"module"],
+	/** @param attribute wc/dom/attribute @param classList wc/dom/classList @param clearSelection wc/dom/clearSelection @param event wc/dom/event @param getMouseEventOffset wc/dom/getEventOffset @param isAcceptableEventTarget wc/dom/isAcceptableTarget @param getBox wc/dom/getBox @param initialise wc/dom/initialise @param shed wc/dom/shed @param uid wc/dom/uid @param Widget wc/dom/Widget @param has wc/has @param processResponse wc/ui/ajax/processResponse @param positionable wc/ui/positionable @param module @ignore */
+	function(attribute, classList, clearSelection, event, getMouseEventOffset, isAcceptableEventTarget, getBox, initialise, shed, uid, Widget, has, processResponse, positionable, module) {
 		"use strict";
 
 		/**
@@ -48,7 +53,8 @@ define(["wc/dom/attribute",
 				dragging,
 				offsetX = {},
 				offsetY = {},
-				KEY_MOVE = parseInt("${wc.ui.draggable.int.keyboardMoveIncrement}", 10),  // the number of pixels by which a draggable is moved by keyboard
+				conf = module.config(),
+				KEY_MOVE = ((conf && conf.step) ? conf.step : 6),  // the number of pixels by which a draggable is moved by keyboard
 				BS = ns + ".inited",
 				MM_EVENT = ns + ".move.inited";
 

--- a/wcomponents-theme/src/main/js/wc/ui/onloadFocusControl.js
+++ b/wcomponents-theme/src/main/js/wc/ui/onloadFocusControl.js
@@ -16,6 +16,12 @@
  * @todo Integrate this with autofocus attribute (note: autofocus does not fire focus events yet).
  * @todo document private members, check source order.
  *
+ * @typedef {object} module:wc/ui/onloadFocusControl.config() Optional module configuration
+ * @property {boolean} rescroll If the document must scroll to bring the focussed element into the viewport this
+ * property determines whether the focussed element is scrolled to teh top (or closest to) of teh viewport (true) or
+ * uses the user agent default - usually to scroll only far enough to bring the element into the viewport.
+ * @default false
+ *
  * @module
  * @requires module:wc/dom/focus
  * @requires module:wc/dom/initialise
@@ -24,14 +30,15 @@
  *
  * @todo Document private members, check source order.
  */
-define(["wc/dom/focus", "wc/dom/initialise", "wc/ui/ajax/processResponse", "wc/timers"],
-	/** @param focus wc/dom/focus @param initialise wc/dom/initialise @param processResponse wc/ui/ajax/processResponse @param timers wc/timers @ignore */
-	function(focus, initialise, processResponse, timers) {
+define(["wc/dom/focus", "wc/dom/initialise", "wc/ui/ajax/processResponse", "wc/timers", "module"],
+	/** @param focus wc/dom/focus @param initialise wc/dom/initialise @param processResponse wc/ui/ajax/processResponse @param timers wc/timers @param module @ignore */
+	function(focus, initialise, processResponse, timers, module) {
 		"use strict";
 		/** @alias module:wc/ui/onloadFocusControl */
 		function OnloadFocusControl() {
 			var focusId,
-				SCROLL_TO_TOP = false,  // true to turn on scroll to top of viewport on load focus, false will apply user agent default (usually scroll to just in view)
+				conf = module.config(),
+				SCROLL_TO_TOP = (conf ? conf.rescroll : false),  // true to turn on scroll to top of viewport on load focus, false will apply user agent default (usually scroll to just in view)
 				FOCUS_DELAY = null;  // if set to a non-negstive integer this will delay focus requests to allow native autofocus to work. Native autofocus is currently problematic since it does not fire a focus event.
 
 

--- a/wcomponents-theme/src/main/js/wc/ui/resizeable.js
+++ b/wcomponents-theme/src/main/js/wc/ui/resizeable.js
@@ -1,6 +1,12 @@
 /**
  * Provides functionality to implement a resizeable component.
  *
+ * @typedef {Object} module:wc/ui.resizeable.config() Optional module configuration.
+ * @property {?int} min The minimum size, in px, any element is allowed to be.
+ * @default 0
+ * @proprty {?int} step The number of pixels to increase/decrease per keypress when resizing with the arrow keys.
+ * @default 6
+ *
  * @module
  * @requires module:wc/dom/attribute
  * @requires module:wc/dom/classList
@@ -32,9 +38,10 @@ define(["wc/dom/attribute",
 		"wc/dom/uid",
 		"wc/dom/Widget",
 		"wc/has",
-		"wc/ui/ajax/processResponse"],
-	/** @param attribute wc/dom/attribute @param classList wc/dom/classList @param clearSelection wc/dom/clearSelection @param event wc/dom/event @param getMouseEventOffset wc/dom/getEventOffset @param isAcceptableTarget wc/dom/isAcceptableTarget @param getBox wc/dom/getBox @param getStyle wc/dom/getStyle @param initialise wc/dom/initialise @param shed wc/dom/shed @param uid wc/dom/uid @param Widget wc/dom/Widget @param has wc/has @param processResponse wc/ui/ajax/processResponse @ignore */
-	function(attribute, classList, clearSelection, event, getMouseEventOffset, isAcceptableTarget, getBox, getStyle, initialise, shed, uid, Widget, has, processResponse) {
+		"wc/ui/ajax/processResponse",
+		"module"],
+	/** @param attribute wc/dom/attribute @param classList wc/dom/classList @param clearSelection wc/dom/clearSelection @param event wc/dom/event @param getMouseEventOffset wc/dom/getEventOffset @param isAcceptableTarget wc/dom/isAcceptableTarget @param getBox wc/dom/getBox @param getStyle wc/dom/getStyle @param initialise wc/dom/initialise @param shed wc/dom/shed @param uid wc/dom/uid @param Widget wc/dom/Widget @param has wc/has @param processResponse wc/ui/ajax/processResponse @param module @ignore */
+	function(attribute, classList, clearSelection, event, getMouseEventOffset, isAcceptableTarget, getBox, getStyle, initialise, shed, uid, Widget, has, processResponse, module) {
 		"use strict";
 		/**
 		 * @constructor
@@ -49,12 +56,13 @@ define(["wc/dom/attribute",
 				RESIZEABLE_HAS_ANIMATION_CLASS = "wc_resizeflow",
 				CLASS_REMOVED_ATTRIB = "data-wc-resizeableremovedanimation",
 				CLASS_MAX = "wc_max",
-				MIN_SIZE = 0,  // set this to any sensible size but will cause errors in IE if < 0
+				conf = module.config(),
+				MIN_SIZE = ((conf && conf.min) ? conf.min : 0), // set this to any sensible size but will cause errors in IE if < 0
 				resizing,
 				offsetX = {},
 				offsetY = {},
 				UNIT = "px",
-				KEY_RESIZE = parseInt("${wc.ui.resizeable.int.keyboardResizeIncrement}", 10),  // the number of pixels by which a resizable is resized by keyboard
+				KEY_RESIZE = ((conf && conf.step) ? conf.step : 6),  // the number of pixels by which a resizable is resized by keyboard
 				ns = "wc.ui.resizeable",
 				BS = ns + ".inited",
 				MM_EVENT = ns + ".move.inited",

--- a/wcomponents-theme/src/main/js/wc/ui/table/rowCheckbox.js
+++ b/wcomponents-theme/src/main/js/wc/ui/table/rowCheckbox.js
@@ -3,15 +3,19 @@
  * {@link module:wc/ui/checkboxAnalog} which is only used to add a grouping container.
  *
  * @module
- * @extends module:wc/ui/checkboxAnalog
+ * @extends module:wc/dom/ariaAnalog
+ *
  * @requires module:wc/dom/Widget
- * @requires module:wc/ui/checkboxAnalog
+ * @requires module:wc/dom/ariaAnalog
  * @requires module:wc/dom/initialise
  * @requires module:wc/ui/radioAnalog
  */
-define(["wc/dom/Widget", "wc/ui/checkboxAnalog", "wc/dom/initialise", "wc/ui/radioAnalog"],
-	/** @param Widget @param checkboxAnalog @param initialise @ignore */
-	function(Widget, checkboxAnalog, initialise) {
+define(["wc/dom/Widget",
+		"wc/dom/ariaAnalog",
+		"wc/dom/initialise",
+		"wc/ui/radioAnalog"],
+	/** @param Widget @param ariaAnalog @param initialise @ignore */
+	function(Widget, ariaAnalog, initialise) {
 		"use strict";
 		/*
 		 * IMPLICIT DEPENDENCIES:
@@ -24,7 +28,7 @@ define(["wc/dom/Widget", "wc/ui/checkboxAnalog", "wc/dom/initialise", "wc/ui/rad
 		 * @constructor
 		 * @alias module:wc/ui/table/rowCheckbox~RowCheckbox
 		 * @private
-		 * @extends module:wc/dom/checkboxAnalog~CheckboxAnalog
+		 * @extends module:wc/dom/ariaAnalog~AriaAnalog
 		 */
 		function RowCheckbox() {
 			/**
@@ -46,6 +50,15 @@ define(["wc/dom/Widget", "wc/ui/checkboxAnalog", "wc/dom/initialise", "wc/ui/rad
 			this.CONTAINER = new Widget("tbody");
 
 			/**
+			 * Enables group selection by storing the start point.
+			 * @var
+			 * @public
+			 * @type {Object}
+			 * @override
+			 */
+			this.lastActivated = {};
+
+			/**
 			 * We have to have an empty write state to prevent the state being written twice. as checkboxAnalog will
 			 * write the state of selected multi-selectable table rows.
 			 * NOTE: formUpdateManager will complain if writeState is anything other than a function.
@@ -53,17 +66,9 @@ define(["wc/dom/Widget", "wc/ui/checkboxAnalog", "wc/dom/initialise", "wc/ui/rad
 			 * @ignore
 			 */
 			this.writeState = function() {};
-
-			/**
-			 * We have to have an empty clickEvent to prevent as checkboxAnalog will handle clicks.
-			 * @todo This may be OK as null rather than as a function.
-			 * @function
-			 * @ignore
-			 */
-			this.clickEvent = function() {};
 		}
 
-		RowCheckbox.prototype = checkboxAnalog;
+		RowCheckbox.prototype = ariaAnalog;
 
 		var /** @alias module:wc/ui/table/rowCheckbox */ instance = new RowCheckbox();
 		instance.constructor = RowCheckbox;

--- a/wcomponents-theme/src/main/js/wc/ui/timeoutWarn.js
+++ b/wcomponents-theme/src/main/js/wc/ui/timeoutWarn.js
@@ -9,6 +9,11 @@
  * <p>There will always be a chance of getting the session timeout wrong, but there is wrong and then
  * there is WRONG. It is better to warn the user too early rather than too late.</p>
  *
+ * @typedef {Object} module:wc/ui.timeoutWarn.config() Optional module configuration.
+ * @property {int} min The minimum timeout (in seconds). If the requested session timeout is less than this we will not
+ * attempt to warn the user.
+ * @default 60
+ *
  * @module
  * @requires external:sprintf/sprintf
  * @requires module:wc/xml/xslTransform
@@ -21,9 +26,9 @@
  *
  * @todo Document private members, check source order.
  */
-define(["sprintf/sprintf", "wc/xml/xslTransform", "wc/dom/event", "wc/dom/Widget", "wc/i18n/i18n", "wc/loader/resource", "wc/dom/shed", "wc/timers"],
-	/** @param sprintf sprintf/sprintf @param xslTransform wc/xml/xslTransform @param event wc/dom/event @param Widget wc/dom/Widget @param i18n wc/i18n/i18n @param loader wc/loader/resource @param shed wc/dom/shed @param timers wc/timers @ignore */
-	function(sprintf, xslTransform, event, Widget, i18n, loader, shed, timers) {
+define(["sprintf/sprintf", "wc/xml/xslTransform", "wc/dom/event", "wc/dom/Widget", "wc/i18n/i18n", "wc/loader/resource", "wc/dom/shed", "wc/timers", "module"],
+	/** @param sprintf sprintf/sprintf @param xslTransform wc/xml/xslTransform @param event wc/dom/event @param Widget wc/dom/Widget @param i18n wc/i18n/i18n @param loader wc/loader/resource @param shed wc/dom/shed @param timers wc/timers @param module @ignore */
+	function(sprintf, xslTransform, event, Widget, i18n, loader, shed, timers, module) {
 		"use strict";
 		/**
 		 * @constructor
@@ -33,7 +38,8 @@ define(["sprintf/sprintf", "wc/xml/xslTransform", "wc/dom/event", "wc/dom/Widget
 		function TimeoutWarner() {
 			var expiresAt,
 				WARN_AT = 20000,  // warn user when this many milliseconds remaining, this default is the WCAG 2.0 minimum of 20 seconds
-				MIN_TIMEOUT = parseInt("${wc.ui.timeoutWarn.minExpire}"),
+				conf = module.config(),
+				MIN_TIMEOUT = (conf ? (conf.min || 30) : 30),
 				timerWarn,
 				timerExpired,
 				CONTAINER_ID = "wc_session_container",

--- a/wcomponents-theme/src/main/plugins/validation/js/textField.js
+++ b/wcomponents-theme/src/main/plugins/validation/js/textField.js
@@ -2,6 +2,10 @@
  * Provides functionality to undertake client validation for text inputs including WTextField, WEmailField,
  * WPhoneNumberField and WPasswordField.
  *
+ * @typedef {Object} module:w${validation.core.path.name}/textField.config() Optional module configuration.
+ * @property {String} rx The email regular expression as a string.
+ * @default "^(?:\\".+\\"|[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+)@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)+$"
+ *
  * @module ${validation.core.path.name}/textField
  * @requires module:wc/dom/initialise
  * @requires module:wc/dom/Widget
@@ -25,9 +29,10 @@ define(["wc/dom/initialise",
 		"wc/ui/dateField",
 		"${validation.core.path.name}/required",
 		"${validation.core.path.name}/validationManager",
-		"wc/ui/textField"],
-	/** @param initialise wc/dom/initialise @param Widget wc/dom/Widget @param i18n wc/i18n/i18n @param attribute wc/dom/attribute @param event wc/dom/event @param getFirstLabelForElement wc/ui/getFirstLabelForElement @param sprintf sprintf/sprintf @param dateField wc/ui/dateField @param required ${validation.core.path.name}/required @param validationManager ${validation.core.path.name}/validationManager @param textField wc/ui/textField @ignore */
-	function(initialise, Widget, i18n, attribute, event, getFirstLabelForElement, sprintf, dateField, required, validationManager, textField) {
+		"wc/ui/textField",
+		"module"],
+	/** @param initialise wc/dom/initialise @param Widget wc/dom/Widget @param i18n wc/i18n/i18n @param attribute wc/dom/attribute @param event wc/dom/event @param getFirstLabelForElement wc/ui/getFirstLabelForElement @param sprintf sprintf/sprintf @param dateField wc/ui/dateField @param required ${validation.core.path.name}/required @param validationManager ${validation.core.path.name}/validationManager @param textField wc/ui/textField @param module @ignore */
+	function(initialise, Widget, i18n, attribute, event, getFirstLabelForElement, sprintf, dateField, required, validationManager, textField, module) {
 		"use strict";
 		/**
 		 * @constructor
@@ -42,7 +47,9 @@ define(["wc/dom/initialise",
 				INPUT_WIDGETS = textField.getWidget(),
 				WITH_PATTERN,
 				PATTERNS,
-				WITH_MIN;
+				WITH_MIN,
+				conf = module.config(),
+				RX_STRING = ((conf && conf.rx) ? conf.rx : "${wc.ui.emailField.regex}");
 
 			/**
 			 * Test for an input which we are interested in.
@@ -100,7 +107,7 @@ define(["wc/dom/initialise",
 					}
 					// pattern (first email)
 					if (EMAIL.isOneOfMe(element)) {
-						regexp = new RegExp("${wc.ui.emailField.regex}");
+						regexp = new RegExp(RX_STRING);
 						patternFlag = i18n.get("${validation.email.i18n.error}");
 					}
 					else if ((mask = element.getAttribute("pattern"))) {

--- a/wcomponents-theme/src/main/properties/wc.ui.backToTop.properties
+++ b/wcomponents-theme/src/main/properties/wc.ui.backToTop.properties
@@ -1,4 +1,1 @@
 wc.ui.backToTop.i18n.text=btt0
-wc.ui.backToTop.opacity.bg=0.1
-wc.ui.backToTop.opacity.fg=0.25
-wc.ui.backToTop.MIN_SCROLL_BEFORE_SHOW=0

--- a/wcomponents-theme/src/main/properties/wc.ui.draggable.properties
+++ b/wcomponents-theme/src/main/properties/wc.ui.draggable.properties
@@ -1,2 +1,0 @@
-#the number of pixels by which a draggable is moved by keyboard. This default is 1/2 the default font size in pixels
-wc.ui.draggable.int.keyboardMoveIncrement=6

--- a/wcomponents-theme/src/main/properties/wc.ui.resizeable.properties
+++ b/wcomponents-theme/src/main/properties/wc.ui.resizeable.properties
@@ -1,2 +1,0 @@
-#the number of pixels by which a resizable is resized by keyboard. This default is 1/2 the default font size in pixels
-wc.ui.resizeable.int.keyboardResizeIncrement=6

--- a/wcomponents-theme/src/main/properties/wc.ui.table.properties
+++ b/wcomponents-theme/src/main/properties/wc.ui.table.properties
@@ -45,7 +45,3 @@ wc.ui.table.string.pagination.label.numberPlaceHolder3=#
 wc.ui.table.string.pagination.label.serverModeButtonText=wdtp8
 wc.ui.table.string.pagination.label.chooseRowsPerPage=wdtp9
 wc.ui.table.string.pagination.label.chooseAllRowsPerPage=wdtp10
-#Table CSS properties
-#table sort control stroke is kinda dependent on the chosen colour scheme
-wc.ui.table.sort.control.svg.stroke.width=stroke-width:2
-wc.ui.table.sort.control.svg.opacity=opacity:0.8

--- a/wcomponents-theme/src/main/properties/wc.ui.timeoutWarn.properties
+++ b/wcomponents-theme/src/main/properties/wc.ui.timeoutWarn.properties
@@ -1,6 +1,3 @@
-wc.ui.timeoutWarn.id.container=wc_session_container
-#minimum expiry time in seconds - the timeout parameter in ui:session must be at least this to trigger a warning
-wc.ui.timeoutWarn.minExpire=30
 wc.ui.timeoutWarn.message.warn.header=twm1
 wc.ui.timeoutWarn.message.warn.body=twm2
 wc.ui.timeoutWarn.message.expired.header=twm3


### PR DESCRIPTION
Fixed a flaw in wc/dom/ariaAnalog which prevented analogues grouped by
a container (such as table row checkboxes) from being selected as a
group.

Fixed a flaw caused by ambiguity between checkbox analogues and
multi-selectable table rows. This needs a bit more work - I had to leak
some knowledge of row checkbox into checkbox analogue.

Added module config facilities to all UI components which have ‘magic’
constants previously set at build time. Removed the ANT properties
(fixes #97).