### PR TITLE
Fix a11y error

### DIFF
--- a/wcomponents-theme/src/main/js/wc/ui/modalShim.js
+++ b/wcomponents-theme/src/main/js/wc/ui/modalShim.js
@@ -137,20 +137,15 @@ define(["wc/dom/attribute", "wc/dom/uid", "wc/dom/classList", "wc/dom/event", "w
 				if (className) {
 					classList.add(shimElement, className);
 				}
-				document.body.setAttribute("aria-hidden", "true");
-				if (activeRegion) {  // NOT activeElement!
-					activeRegion.setAttribute("aria-hidden", "false");
-				}
 
-				function disableElement(next) {
+				// remove the accesskey attribute from controls with access keys which are not in the activeRegion
+				Array.prototype.forEach.call(ACCESS_KEY_WD.findDescendants(document), function(next) {
 					var nextId = next.id || (next.id = uid());
 					if (activeRegion && !(activeRegion.compareDocumentPosition(next) & Node.DOCUMENT_POSITION_CONTAINS)) {  // deliberate use of local variable here
 						accessKeyMap[nextId] = next.getAttribute(AKEY);
 						next.removeAttribute(AKEY);
 					}
-				}
-				// remove the accesskey attribute from controls with access keys which are not in the activeRegion
-				Array.prototype.forEach.call(ACCESS_KEY_WD.findDescendants(document), disableElement);
+				});
 			};
 
 			/**
@@ -169,14 +164,10 @@ define(["wc/dom/attribute", "wc/dom/uid", "wc/dom/classList", "wc/dom/event", "w
 								aKeyElement.setAttribute(AKEY, accessKeyMap[key]);
 							}
 						}
-						document.body.removeAttribute("aria-hidden");
 						shed.hide(shimElement, true);
 					}
 				}
 				finally {
-					if (activeElement) {
-						activeElement.removeAttribute("aria-hidden");
-					}
 					activeElement = null;
 					accessKeyMap = {};
 				}


### PR DESCRIPTION
We erroneously applied aria-hidden=‘true’ to content underlying the
modal shim. This is an error because the modal is inside this content
so setting it to aria-hidden=‘false’ is pointless as conforming AT will
never get to it since it has a hidden ancestor.