### PR TITLE
Ie css

### DIFF
--- a/wcomponents-theme/src/main/js/wc/loader/style.js
+++ b/wcomponents-theme/src/main/js/wc/loader/style.js
@@ -46,8 +46,10 @@
  * @module
  * @requires module:wc/has
  * @todo Maybe allow load to accept an Object or Object[] arg so it can be called from within another module?
+ * @todo dojo/sniff has been patched to include has("edge") but it not yet released. The include of fixes here is to
+ * include our has test for edge. It can be removed once dojo/sniff is updated.
  */
-define(["wc/has", "module"], /** @param has wc/has @param module module @ignore */ function(has, module) {
+define(["wc/has", "wc/fixes", "module"], /** @param has wc/has @param module module @ignore */ function(has, fixes, module) {
 	"use strict";
 	/**
 	 * @constructor

--- a/wcomponents-theme/src/main/js/wc/loader/style.js
+++ b/wcomponents-theme/src/main/js/wc/loader/style.js
@@ -314,9 +314,6 @@ define(["wc/has", "module"], /** @param has wc/has @param module module @ignore 
 					}
 				}
 			}
-			if (isDebug) {
-				addStyle("debug", "screen");
-			}
 		};
 	}
 	return /** @alias module:wc/loader/style */ new StyleLoader();

--- a/wcomponents-theme/src/main/sass/README.md
+++ b/wcomponents-theme/src/main/sass/README.md
@@ -18,7 +18,7 @@ we have the following conventions:
     * if for Internet Explorer `/^.*\.ie[0-9]+\.scss$/`;
     * otherwise `/^.*\.pattern_[^\.]+\.scss$/`
 
-    These files are loaded using the JavaScript module wc/loader/style so you might want to look at the doco for that!.
+    These files are loaded using the JavaScript module wc/loader/style so you might want to look at the doco for that!
 
 ### Platform/browser patterns
 
@@ -29,25 +29,18 @@ object which can contain much more specialised `has` test and media rules. See t
 For example if your Sass includes a file named `foo.pattern_ff.scss` then the build process will generate a concatenated
 CSS file `screen.ff.css` and the CSS loader will be told to load this file if `has("ff")` is true.
 
+If you need CSS for IE before IE8 I recommend adding a conditional comment in the XSLT rather than relying on the style
+loader as early versions of IE are rubbish at using CSS loaded by JavaScript.
+
 ## Coding Standards
 
 * All Sass must be in SCSS format.
 * Generated CSS **must** comply with the [CSS standards](http://www.w3.org/Style/CSS/) and we use CSS3 except where
-  vendor extensions are **absolutely required** for consistent implementation (e.g. the use of -moz-box-sizing).
+  vendor extensions are **absolutely required** for consistent implementation.
 * The preferred line length is 120 characters but this is flexible within sensible limits - go over by a bit if you have
   to to keep a selector on one line.
-* Sass should be linted. The lint rules are here to make the SCSS more readable for humans and are the defaults for
-  scss-lint with the following exceptions:
-    * CSS comments are allowed only as the file head and tail comment (see below for details);
-    * @else must be placed on a new line;
-    * @import must include the file extension (this is to improve integration with common IDE's auto-complete);
-    * indentation is by **TAB** ONLY - single tab per level of indent;
-    * leading zeros are required (eg 0.5em _not_ .5em);
-    * nesting depth is limited to 4 levels and is under review (some deeper nesting is already locally overridden);
-    * selector depth is limited to 4 levels and is under review (some deeper nesting is already locally overridden);
-    * selector format is disabled to allow for a mix of XML element and attribute local-names (which are often
-      camelCase) and custom class names which are currently in underscore separated lowercase (this is also under
-      review).
+* Sass should be linted. The lint rules are here to make the SCSS more readable for humans and are mostly the defaults
+  for scss-lint; exceptions to which are documented in the included ``.scss-lint.yaml` configuration file.
 * Local variations in scss-lint rules are allowed but must be commented. Most commonly this would be to allow local
   !important rules.
 
@@ -64,22 +57,25 @@ CSS file `screen.ff.css` and the CSS loader will be told to load this file if `h
 * Do not place a CSS style comment inside a declaration block (it causes issues with Safari's developer tools). Sass
   single line comments are permitted inside rule blocks.
 * If a particular selector in a multi-selector rule requires a comment it should be placed on the same line as the
-  selector. If the comment is CSS style then it must precede the comma or opening brace (if it is the last selector).
-  Sass comments must always be at the end of a line (of course).
+  selector.
 
 #### Example
 
-    /* wc.my.component.scss */
-	//scss-lint:disable Comment
-    /* This declaration block does something odd and I need to know about it in debug mode */
-	//scss-lint:enable Comment
-    .foo,
-    .bar > .somelongclassname [aria-selected='true'] > :first-child {
-        ....
-        line-height: -2px; // The line-height declaration is used to ... which is needed for ...
-        ....
+``` scss
+/* wc.my.component.scss */
+@import 'mixins_common.scss';
+
+//scss-lint:disable Comment
+/* This declaration block does something odd and I need to know about it in debug mode */
+//scss-lint:enable Comment
+.foo, // foo class is for all foos!
+.bar > .somelongclassname [aria-selected='true'] > :first-child {
+    // ....
+    line-height: -2px; // This is needed for ...
+    // ....
     }
-    /* end wc.my.component.scss */
+/* end wc.my.component.scss */
+```
 
 ## Media rules and specific CSS: when to use which
 

--- a/wcomponents-theme/src/main/sass/mixins_common.scss
+++ b/wcomponents-theme/src/main/sass/mixins_common.scss
@@ -23,19 +23,22 @@
 }
 
 /// Create a button with a transparent background. Handy for holding iconography!
-/// @param {boolean} $border [true] Set false to not include the standard border mixin.
+/// @param {color} $background [transparent] Set the button background. Set -1 to ignore this rule.
+/// @param {boolean} $border [true] Set false to not include the standard border mixin. If you want a non-standard border set false and use the border mixin by itself.
 /// @param {dimension} $height [$line-size] The height of the button. Set -1 to omit this rule.
 /// @param {dimension} $padding [1em] The padding of the button. Set -1 to omit this rule.
 /// @param {position} $text-align [center] The text align for your button. Set '' to omit this rule.
 /// @param {dimension} $width [$line-size] The width of the button. Set -1 to omit this rule.
-@mixin button ($border: true, $height: $line-size, $padding: $hgap-small, $text-align: center, $width: $line-size, $reset-height: 1em, $reset-width: 1em) {
+@mixin button ($background: transparent, $border: true, $height: $line-size, $padding: $hgap-small, $text-align: center, $width: $line-size, $reset-height: 1em, $reset-width: 1em) {
 	@if ($border == true) {
 		@include border;
 	}
 	@else if ($border == 0) {
 		border: 0;
 	}
-	background-color: transparent;
+	@if($background != -1) {
+		background-color: $background;
+	}
 	// need this for Firefox
 	// scss-lint:disable VendorPrefix
 	-moz-box-sizing: content-box;

--- a/wcomponents-theme/src/main/sass/wc.ui.fileUpload.ie11.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.fileUpload.ie11.scss
@@ -1,5 +1,10 @@
 /* wc.ui.fileUpload.ie11.scss */
 @import 'mixins_common.scss';
+
+.fileUpload .file {
+	padding-right: 3px; // IE11 cannot calc 100% - 1.333 em and set a right pad in em at the same time. Useless POS.
+}
+
 // The default file upload in IE is a bit ugly if anything is styled at all. This CSS may be considered lipstick. If we
 // cannot style the pseudo elements (IE9-) then it can remain ugly.
 //scss-lint:disable VendorPrefix

--- a/wcomponents-theme/src/main/sass/wc.ui.multiFormComponent.icons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.multiFormComponent.icons.scss
@@ -7,7 +7,7 @@
 		@include button($border: 0, $padding: 0);
 		@include background-image-icon('../images/delete.png');
 		margin-left: $hgap-small;
-		vertical-align: text-top;
+		vertical-align: text-bottom;
 
 		&[disabled] {
 			background-image: url('../images/delete-d.png');
@@ -26,4 +26,3 @@
 		vertical-align: top;
 	}
 }
-/* end wc.ui.multiFormComponent.icons.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.table.pagination.icons.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.pagination.icons.scss
@@ -3,10 +3,11 @@
 
 // The deep nesting and repition here is necessitated by IE8's (and earlier)) lack of nth-child
 .wc_table_pag_cont .wc_ibtn {
+	padding: $vgap-small;
 	vertical-align: middle;
 
 	&::before {
-		@include make-box;
+		@include make-box($display: block);
 		@include background-image('../images/first.png', $height: 1em, $width: 1em);
 		content: ' ';
 	}

--- a/wcomponents-theme/src/main/sass/wc.ui.table.pagination.ie11.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.pagination.ie11.scss
@@ -2,8 +2,6 @@
 @import 'mixins_common.scss';
 
 .wc_table_pag_cont .wc_ibtn {
-	padding: $vgap-small;
-
 	&:before {
 		height: 1em;
 		vertical-align: text-bottom;

--- a/wcomponents-theme/src/main/sass/wc.ui.table.pagination.ie11.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.pagination.ie11.scss
@@ -1,6 +1,14 @@
 /* wc.ui.table.pagination.ie11.scss */
+@import 'mixins_common.scss';
+
 .wc_table_pag_cont .wc_ibtn {
-	padding: 0 0.25em;
-	vertical-align: text-bottom;
+	padding: $vgap-small;
+
+	&:before {
+		height: 1em;
+		vertical-align: text-bottom;
+		width: 1em;
+	}
 }
+
 /* end wc.ui.table.pagination.ie11.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.table.pagination.ie8.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.pagination.ie8.scss
@@ -7,9 +7,5 @@
 	select + .wc_ibtn { // no first of type
 		margin-left: $hgap-large;
 	}
-
-	.wc_ibtn {
-		vertical-align: baseline;
-	}
 }
 /* end wc.ui.table.pagination.ie8.scss */

--- a/wcomponents-theme/src/main/sass/wc.ui.table.pagination.pattern_edge.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.table.pagination.pattern_edge.scss
@@ -1,0 +1,4 @@
+/* wc.ui.table.pagination.pattern_edge.scss */
+.wc_table_pag_cont .wc_ibtn {
+	padding: 0;
+}

--- a/wcomponents-theme/src/main/sass/wc.ui.text.scss
+++ b/wcomponents-theme/src/main/sass/wc.ui.text.scss
@@ -16,7 +16,7 @@
 	padding: 0 $hgap-small;
 }
 
-.mandatory-indicator:after {
+.mandatoryIndicator:after {
 	@include mandatory-indicator;
 	margin-left: $hgap-small;
 }


### PR DESCRIPTION
Fixed up some more minor display issues in IE8-11 and Edge. Had to
include wc/fixes as a dependency in wc/loader/style to get has(“edge”)
in time. This can be reversed once dojo release their sniff update.